### PR TITLE
use OCS_FILTER setting for lldp info

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Tested with ArubaOS-CX versions:
 - 10.6
 - 10.7
 - 10.9
+- 10.12
 
 ## Official Status
 

--- a/arubaoscx.pm
+++ b/arubaoscx.pm
@@ -161,7 +161,9 @@ sub CommentOutput {
     chomp;
 
     # Display the command we're processing in the output:
-    ProcessHistory("COMMENTS", "", "", "!\n! '$cmd':\n!\n");
+    unless ( ( $cmd eq 'show lldp neighbor-info') && ( $filter_osc >= 1 ) ) {
+        ProcessHistory("COMMENTS", "", "", "!\n! '$cmd':\n!\n");
+    }
 
     while (<$INPUT>) {
         tr/\015//d;
@@ -245,6 +247,7 @@ sub CommentOutput {
         }
 
         if ( $cmd eq 'show lldp neighbor-info' ) {
+            next if ($filter_osc >= 1);
             next if /^Total Neighbor Entries (Deleted|Dropped|Aged-Out)\s+:/;
         }
 


### PR DESCRIPTION
first of; thx for this module - saved me a lot of time.

we only have devices running 10.12, so updated the readme to indicate this version has also been tested.

anyway, we recently had an influx of lldp enabled enduser devices, and with a hourly rancid run this started to generate way to many diffs for lldp neighbors. since rancid has a setting for volatile data named FILTER_OSC i wrote a small patch to make lldp use this. the setting can be set to no (default), yes & all. since lldp info is completely dynamic i opted that the that a setting of "yes" suitable over "all". see `man 5 rancid.conf` for details (my actual ~/etc/rancid.conf doesn't mention the "all" setting, the manpage does)

also, you could just comment out the lldp line in rancid.types.conf

it feels somewhat cludgy to ignore printing the command using that unless() construct but since CommentOutput handles everything else i didn't feel the need to split the lldp handling in a new module.
i used seperate modules for aerohive support, but it also produces a lot of duplicate code
https://github.com/inphobia/rancid-aerohive-support/blob/master/lib/hiveos.pm.in

5 line diff, 4 paragraphs of text for the pull request :)